### PR TITLE
gtksourceview syntax improvements

### DIFF
--- a/gedit/singularity.lang
+++ b/gedit/singularity.lang
@@ -6,44 +6,12 @@
     <property name="line-comment-start">#</property>
   </metadata>
   <styles>
-    <style id="comment" name="Comment" map-to="def:comment"/>
-    <style id="string" name="String" map-to="def:string"/>
-    <style id="escaped-character" name="Escaped Character" map-to="def:special-char"/>
     <style id="preprocessor" name="Preprocessor" map-to="def:preprocessor"/>
-    <style id="char" name="Character" map-to="def:character"/>
     <style id="keyword" name="Keyword" map-to="def:keyword"/>
-    <style id="type" name="Data Type" map-to="def:type"/>
   </styles>
   <definitions>
     <context id="singularity">
       <include>
-
-        <context id="comment" style-ref="comment">
-          <start>#</start>
-          <end>$</end>
-        </context>
-
-        <context id="string" end-at-line-end="true" style-ref="string">
-          <start>"</start>
-          <end>"</end>
-          <include>
-            <context id="escape" style-ref="escaped-character">
-              <match>\\.</match>
-            </context>
-          </include>
-        </context>
-
-        <context id="char" end-at-line-end="true" style-ref="string">
-          <start>'</start>
-          <end>'</end>
-          <include>
-            <context ref="escape"/>
-          </include>
-        </context>
-
-        <context ref="def:decimal"/>
-        <context ref="def:float"/>
-
         <context id="keywords" style-ref="keyword">
           <suffix>:</suffix>
           <keyword>Bootstrap</keyword>
@@ -79,6 +47,7 @@
           <keyword>appfiles</keyword>
         </context>
 
+        <context ref="sh:sh"/>
       </include>
     </context>
   </definitions>

--- a/gedit/singularity.lang
+++ b/gedit/singularity.lang
@@ -3,6 +3,7 @@
 <language id="singularity" name="Singularity" version="2.0" _section="Source">
   <metadata>
     <property name="globs">Singularity;Singularity.*;*.def</property>
+    <property name="line-comment-start">#</property>
   </metadata>
   <styles>
     <style id="comment" name="Comment" map-to="def:comment"/>
@@ -44,11 +45,19 @@
         <context ref="def:float"/>
 
         <context id="keywords" style-ref="keyword">
+          <suffix>:</suffix>
           <keyword>Bootstrap</keyword>
           <keyword>From</keyword>
           <keyword>OSVersion</keyword>
           <keyword>MirrorURL</keyword>
           <keyword>Include</keyword>
+          <keyword>Stage</keyword>
+          <keyword>Library</keyword>
+          <keyword>Stage</keyword>
+          <keyword>Registry</keyword>
+          <keyword>Namespace</keyword>
+          <keyword>IncludeCmd</keyword>
+          <keyword>Stage</keyword>
         </context>
 
         <context id="preprocessor" style-ref="preprocessor">
@@ -60,6 +69,7 @@
           <keyword>environment</keyword>
           <keyword>post</keyword>
           <keyword>runscript</keyword>
+          <keyword>startscript</keyword>
           <keyword>test</keyword>
           <keyword>apphelp</keyword>
           <keyword>applabels</keyword>

--- a/gedit/singularity.lang
+++ b/gedit/singularity.lang
@@ -16,35 +16,33 @@
           <suffix>:</suffix>
           <keyword>Bootstrap</keyword>
           <keyword>From</keyword>
-          <keyword>OSVersion</keyword>
-          <keyword>MirrorURL</keyword>
-          <keyword>Include</keyword>
-          <keyword>Stage</keyword>
-          <keyword>Library</keyword>
-          <keyword>Stage</keyword>
-          <keyword>Registry</keyword>
-          <keyword>Namespace</keyword>
           <keyword>IncludeCmd</keyword>
+          <keyword>Include</keyword>
+          <keyword>Library</keyword>
+          <keyword>MirrorURL</keyword>
+          <keyword>Namespace</keyword>
+          <keyword>OSVersion</keyword>
+          <keyword>Registry</keyword>
           <keyword>Stage</keyword>
         </context>
 
         <context id="preprocessor" style-ref="preprocessor">
           <prefix>^%</prefix>
-          <keyword>help</keyword>
-          <keyword>setup</keyword>
-          <keyword>files</keyword>
-          <keyword>labels</keyword>
+          <keyword>appenv</keyword>
+          <keyword>appfiles</keyword>
+          <keyword>apphelp</keyword>
+          <keyword>appinstall</keyword>
+          <keyword>applabels</keyword>
+          <keyword>apprun</keyword>
           <keyword>environment</keyword>
+          <keyword>files</keyword>
+          <keyword>help</keyword>
+          <keyword>labels</keyword>
           <keyword>post</keyword>
           <keyword>runscript</keyword>
+          <keyword>setup</keyword>
           <keyword>startscript</keyword>
           <keyword>test</keyword>
-          <keyword>apphelp</keyword>
-          <keyword>applabels</keyword>
-          <keyword>appinstall</keyword>
-          <keyword>appenv</keyword>
-          <keyword>apprun</keyword>
-          <keyword>appfiles</keyword>
         </context>
 
         <context ref="sh:sh"/>


### PR DESCRIPTION
I noticed that a few keywords are missing and added them.

Additionally I added `<context ref="sh:sh"/>` instead of trying to redevelop shell syntax and removed the now unnecessary parts.

One could go fancy and try things like the following to get shell syntax highlighting only for shell sections, which would be great. However I'm not 100% this works as done. It will certainly fail if a script contains a leading percent sign somehow

        <context id="command-section">
          <start>^%(setup|environment|post|(run|start)script|test|app(install|env|run))\b</start>
          <end>(?=^%)</end>
          <include>
            <context sub-pattern="0" where="start" style-ref="preprocessor"/>
            <context ref="sh:sh"/>
          </include>
        </context>