### PR TITLE
Define comments and commentstring in vim plugin

### DIFF
--- a/vim/Makefile
+++ b/vim/Makefile
@@ -1,11 +1,15 @@
 install:
 	mkdir -p ~/.vim/syntax
 	mkdir -p ~/.vim/ftdetect
+	mkdir -p ~/.vim/ftplugin
 	cp syntax/singularity.vim ~/.vim/syntax/
 	cp ftdetect/singularity.vim ~/.vim/ftdetect/
+	cp ftplugin/singularity.vim ~/.vim/ftplugin/
 
 uninstall:
 	rm ~/.vim/syntax/singularity.vim
 	rm ~/.vim/ftdetect/singularity.vim
+	rm ~/.vim/ftlugin/singularity.vim
 	rmdir ~/.vim/syntax
 	rmdir ~/.vim/ftdetect
+	rmdir ~/.vim/ftplugin

--- a/vim/ftplugin/singularity.vim
+++ b/vim/ftplugin/singularity.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=#%s

--- a/vim/ftplugin/singularity.vim
+++ b/vim/ftplugin/singularity.vim
@@ -1,1 +1,2 @@
+setlocal comments=b:#
 setlocal commentstring=#%s

--- a/vim/ftplugin/singularity.vim
+++ b/vim/ftplugin/singularity.vim
@@ -1,2 +1,2 @@
 setlocal comments=b:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s


### PR DESCRIPTION
This defines two extra variables in the vim plugin.

These are/may be useful for plugins which take advantage of knowing the comment string/format like https://github.com/tpope/vim-commentary.