### PR TITLE
Add vim indent plugin

### DIFF
--- a/vim/Makefile
+++ b/vim/Makefile
@@ -1,11 +1,15 @@
 install:
 	mkdir -p ~/.vim/syntax
 	mkdir -p ~/.vim/ftdetect
+	mkdir -p ~/.vim/ftplugin
 	cp syntax/singularity.vim ~/.vim/syntax/
 	cp ftdetect/singularity.vim ~/.vim/ftdetect/
+	cp ftplugin/singularity.vim ~/.vim/ftplugin/
 
 uninstall:
 	rm ~/.vim/syntax/singularity.vim
 	rm ~/.vim/ftdetect/singularity.vim
+	rm ~/.vim/ftlugin/singularity.vim
 	rmdir ~/.vim/syntax
 	rmdir ~/.vim/ftdetect
+	rmdir ~/.vim/ftplugin

--- a/vim/Makefile
+++ b/vim/Makefile
@@ -2,14 +2,18 @@ install:
 	mkdir -p ~/.vim/syntax
 	mkdir -p ~/.vim/ftdetect
 	mkdir -p ~/.vim/ftplugin
+	mkdir -p ~/.vim/indent
 	cp syntax/singularity.vim ~/.vim/syntax/
 	cp ftdetect/singularity.vim ~/.vim/ftdetect/
 	cp ftplugin/singularity.vim ~/.vim/ftplugin/
+	cp indent/singularity.vim ~/.vim/indent/
 
 uninstall:
 	rm ~/.vim/syntax/singularity.vim
 	rm ~/.vim/ftdetect/singularity.vim
 	rm ~/.vim/ftlugin/singularity.vim
+	rm ~/.vim/indent/singularity.vim
 	rmdir ~/.vim/syntax
 	rmdir ~/.vim/ftdetect
 	rmdir ~/.vim/ftplugin
+	rmdir ~/.vim/indent

--- a/vim/ftplugin/singularity.vim
+++ b/vim/ftplugin/singularity.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=#%s

--- a/vim/ftplugin/singularity.vim
+++ b/vim/ftplugin/singularity.vim
@@ -1,1 +1,2 @@
+setlocal comments=b:#
 setlocal commentstring=#%s

--- a/vim/ftplugin/singularity.vim
+++ b/vim/ftplugin/singularity.vim
@@ -1,2 +1,2 @@
 setlocal comments=b:#
-setlocal commentstring=#%s
+setlocal commentstring=#\ %s

--- a/vim/indent/singularity.vim
+++ b/vim/indent/singularity.vim
@@ -50,14 +50,14 @@ function! GetSingularityIndent(lnum)
 
         " If parent section is one of
         " %setup,%files,%post,%test,%environment,%startscript,%runscript,%labels,%help
-        " increase indent one step (or make indent level 1?)
+        " increase indent one step
         if current_line =~ '^%\(setup\|files\|post\|test\|environment\|startscript\|runscript\|labels\|help\)'
             return indent(clnum) + &shiftwidth
         endif
 
         " If parent section is one of
         " %apprun *,%applabels *,%appinstall *,%appenv *,%apphelp *,%appfiles *
-        " increase indent one step (or make indent level 1?)
+        " increase indent one step
         if current_line =~ '^%\(apprun\|applabels\|appinstall\|appenv\|apphelp\|appfiles\)\s*[a-zA-Z]*'
             return indent(clnum) + &shiftwidth
         endif

--- a/vim/indent/singularity.vim
+++ b/vim/indent/singularity.vim
@@ -21,7 +21,6 @@ setlocal indentkeys=!^F,o,O,0%,<:>
 " Returns the level of indentation as an integer
 " -1 means to retain the current indentation level
 function! GetSingularityIndent(lnum)
-    " echom "Indenting line " lnum
     let lnum = a:lnum
 
     " The first line is at indent level 0
@@ -34,7 +33,6 @@ function! GetSingularityIndent(lnum)
     " Catch indentation triggered when typing %, for section headings set
     " indent to level 0
     if this_line =~ '^\s*%'
-        " echom "Section beginning (%), indenting to level 0"
         return 0
     endif
 
@@ -54,7 +52,6 @@ function! GetSingularityIndent(lnum)
         " %setup,%files,%post,%test,%environment,%startscript,%runscript,%labels,%help
         " increase indent one step (or make indent level 1?)
         if current_line =~ '^%\(setup\|files\|post\|test\|environment\|startscript\|runscript\|labels\|help\)'
-            " echom "Previous line was section beginning, increasing indentation by shiftwidth: " &shiftwidth
             return indent(clnum) + &shiftwidth
         endif
 
@@ -62,7 +59,6 @@ function! GetSingularityIndent(lnum)
         " %apprun *,%applabels *,%appinstall *,%appenv *,%apphelp *,%appfiles *
         " increase indent one step (or make indent level 1?)
         if current_line =~ '^%\(apprun\|applabels\|appinstall\|appenv\|apphelp\|appfiles\)\s*[a-zA-Z]*'
-            " echom "Previous line was app section beginning, increasing indentation by shiftwidth: " &shiftwidth
             return indent(clnum) + &shiftwidth
         endif
 

--- a/vim/indent/singularity.vim
+++ b/vim/indent/singularity.vim
@@ -38,7 +38,7 @@ function! GetSingularityIndent(lnum)
 
     " Trigger indentation when typing :, if line matches a keyword set indent
     " to level 0
-    if this_line =~ '^\s*\(Bootstrap\|From\|OSVersion\|MirrorURL\|Library\|Registry\|Namespace\|IncludeCmd\|Include\):'
+    if this_line =~ '^\s*\(Bootstrap\|From\|Stage\|OSVersion\|MirrorURL\|Library\|Registry\|Namespace\|IncludeCmd\|Include\):'
         return 0
     endif
 

--- a/vim/indent/singularity.vim
+++ b/vim/indent/singularity.vim
@@ -15,13 +15,11 @@ setlocal autoindent
 setlocal indentexpr=GetSingularityIndent(v:lnum)
 
 " Declare which keys trigger the indentation function
-setlocal indentkeys=!^F,o,O,0%
+setlocal indentkeys=!^F,o,O,0%,<:>
 
 " Indentation level function
 " Returns the level of indentation as an integer
 " -1 means to retain the current indentation level
-"
-" Should add rules for handling the header (Bootstrap:, From:, etc.)
 function! GetSingularityIndent(lnum)
     " echom "Indenting line " lnum
     let lnum = a:lnum
@@ -31,13 +29,21 @@ function! GetSingularityIndent(lnum)
         return 0
     endif
 
-    " Trigger indentation when typing %, if line matches regex '^\s*%\*$' set indent to
-    " level 0
     let this_line = getline(lnum)
+
+    " Catch indentation triggered when typing %, for section headings set
+    " indent to level 0
     if this_line =~ '^\s*%'
         " echom "Section beginning (%), indenting to level 0"
         return 0
     endif
+
+    " Trigger indentation when typing :, if line matches a keyword set indent
+    " to level 0
+    if this_line =~ '^\s*\(Bootstrap\|From\|OSVersion\|MirrorURL\|Library\|Registry\|Namespace\|IncludeCmd\|Include\):'
+        return 0
+    endif
+
 
     " Search backwards for the section lnum belongs to
     let clnum = lnum - 1

--- a/vim/indent/singularity.vim
+++ b/vim/indent/singularity.vim
@@ -30,6 +30,11 @@ function! GetSingularityIndent(lnum)
     " echom "Indenting line " lnum
     let lnum = a:lnum
 
+    " The first line is at indent level 0
+    if lnum == 1
+        return 0
+    endif
+
     " Trigger indentation when typing %, if line matches regex '^\s*%\*$' set indent to
     " level 0
     let this_line = getline(lnum)

--- a/vim/indent/singularity.vim
+++ b/vim/indent/singularity.vim
@@ -58,7 +58,7 @@ function! GetSingularityIndent(lnum)
         " If parent section is one of
         " %apprun *,%applabels *,%appinstall *,%appenv *,%apphelp *,%appfiles *
         " increase indent one step
-        if current_line =~ '^%\(apprun\|applabels\|appinstall\|appenv\|apphelp\|appfiles\)\s*[a-zA-Z]*'
+        if current_line =~ '^%\(apprun\|applabels\|appinstall\|appenv\|apphelp\|appfiles\|apptest\)\s*[a-zA-Z]*'
             return indent(clnum) + &shiftwidth
         endif
 

--- a/vim/indent/singularity.vim
+++ b/vim/indent/singularity.vim
@@ -1,0 +1,62 @@
+" Singularity indent file
+
+" Only load this script if no other indent script has been loaded
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent=1
+
+" Configure other indent options
+setlocal nocindent
+setlocal nosmartindent
+setlocal autoindent
+
+" Declare function to determine indent level
+setlocal indentexpr=GetSingularityIndent(v:lnum)
+
+" Declare which keys trigger the indentation function
+setlocal indentkeys=!^F,o,O,0%
+
+" Indentation level function
+" Returns the level of indentation as an integer
+" -1 means to retain the current indentation level
+"
+" Not robust enough, needs to work backwards until the beginning of the last
+" block (otherwise we don't know how to indent a line part way through a
+" block)
+"
+" Should add rules for handling the header (Bootstrap:, From:, etc.)
+function! GetSingularityIndent(lnum)
+    " echom "Indenting line " lnum
+    let lnum = a:lnum
+
+    " Trigger indentation when typing %, if line matches regex '^\s*%\*$' set indent to
+    " level 0
+    let this_line = getline(lnum)
+    if this_line =~ '^\s*%'
+        " echom "Section beginning (%), indenting to level 0"
+        return 0
+    endif
+
+    let plnum = lnum - 1
+    let previous_line = getline(plnum)
+
+    " If previous line is one of
+    " %setup,%files,%post,%test,%environment,%startscript,%runscript,%labels,%help
+    " increase indent one step (or make indent level 1?)
+    if previous_line =~ '^%\(setup\|files\|post\|test\|environment\|startscript\|runscript\|labels\|help\)'
+        " echom "Previous line was section beginning, increasing indentation by shiftwidth: " &shiftwidth
+        return indent(plnum) + &shiftwidth
+    endif
+
+    " If previous line is one of
+    " %apprun *,%applabels *,%appinstall *,%appenv *,%apphelp *,%appfiles *
+    " increase indent one step (or make indent level 1?)
+    if previous_line =~ '^%\(apprun\|applabels\|appinstall\|appenv\|apphelp\|appfiles\)\s*[a-zA-Z]*'
+        " echom "Previous line was app section beginning, increasing indentation by shiftwidth: " &shiftwidth
+        return indent(plnum) + &shiftwidth
+    endif
+
+    " Otherwise return same indent level
+    return -1
+endfunction


### PR DESCRIPTION
Hi,

This PR adds an indent plugin for singularity def files for vim.

It will,

- Indent section headings (`%environment`, `%setup`, etc.) including app sections (`%apprun`, `%apphelp`, etc.) to column 0
- Indent keywords (those that I found [here](https://sylabs.io/guides/3.5/user-guide/appendix.html#keywords)) to column 0
- Indent the contents of each section to one level deeper than the section heading (using the vim parameter `shiftwidth`)
- Trigger indentation in response to
  - typing `%` at the beginning of a line (like a section heading)
  - typing `:` (like after a keyword)
  - creating a new line with `o` or `O` (in normal mode) or when pressing return in insert mode
  - pressing ctrl+f in insert mode

This does a (pretty) good job of indenting a def file as you are typing it, and you can use `=` to autoindent sections of a file or an entire file. For example,

```
Bootstrap: library
    From: ubuntu:18.04
        Stage: build

%setup
touch /file1
touch ${SINGULARITY_ROOTFS}/file2

    %files
            /file1
        /file1 /opt

%environment
    export LISTEN_PORT=12345
    export LC_ALL=C
```

typing `gg=G`

will give

```
Bootstrap: library
From: ubuntu:18.04
Stage: build

%setup
    touch /file1
    touch ${SINGULARITY_ROOTFS}/file2

%files
    /file1
    /file1 /opt

%environment
    export LISTEN_PORT=12345
    export LC_ALL=C
```

There are a couple of limitation that I know of. 

The plugin will not automatically indent commands inside a section like the if block in [this example](https://sylabs.io/guides/3.5/user-guide/definition_files.html#test). Instead, it will indent the entire contents of the section to the same level.

The plugin will not recognise 'top level comments' like [this example](https://sylabs.io/guides/3.5/user-guide/definition_files.html#apps) where comment blocks are used to make the separation between apps clear. Instead, these comments will be indented to the same level as the contents of the last section. I don't know if there is a formal way to signify the difference between 'exiting' a section and just leaving blank lines within a section for readability.