### PR TITLE
Add extra flags to formatoptions

### DIFF
--- a/vim/ftplugin/singularity.vim
+++ b/vim/ftplugin/singularity.vim
@@ -1,2 +1,4 @@
 setlocal comments=b:#
 setlocal commentstring=#\ %s
+
+setlocal formatoptions+=tcroqj


### PR DESCRIPTION
Hi,

This change will _add_ some flags to the `formatoptions` parameter when loading the vim plugin in addition to whatever the user might have defined in their own configuration.

The flags are,

- `t` - wraps text using `textwidth`
- `c` - wraps comments using `textwidth` and automatically inserts the comment leader (works nicely with the comments variables set in my previous PR)
- `r`,`o` - automatically inserts the comment leader when creating a new line in a comment in insert and normal modes respectively
- `q` - formats comments using `gq` (removes the comment leading when combining lines or adding the comment leader when creating a new line)
- `j` - removes the comment leading when manually combining lines with `j`

These settings make typing comments friendlier and fix some problems I noticed,

- Pressing Enter while typing a comment will now automatically insert a `#` to continue the comment.
- Joining two comment lines with `j` will remove extra `#`'s
- Auto formatting comments (for example `gqip`) will insert or remove `#`'s as appropriate.