### PR TITLE
vim: Add 'arguments' and 'startscript' headers

### DIFF
--- a/vim/syntax/singularity.vim
+++ b/vim/syntax/singularity.vim
@@ -17,6 +17,7 @@ syn keyword singularitySectionName contained help setup files labels
 syn keyword singularitySectionName contained environment post runscript test
 syn keyword singularitySectionName contained apphelp applabels appinstall
 syn keyword singularitySectionName contained appenv apprun appfiles
+syn keyword singularitySectionName contained arguments startscript
 
 " TODO variable dereferencing
 


### PR DESCRIPTION
Add 'arguments' and 'startscript' to the list of section names for the vim highlighting.